### PR TITLE
Refactor check_only_instances() functionality

### DIFF
--- a/backup
+++ b/backup
@@ -7,6 +7,9 @@
 # Version:      0.9.3
 # Usage:        bash /etc/cron.hourly/backup
 
+#Use flock(1) to ensure that ths script only has one instance.
+[ "${FLOCKER}" != "$0" ] && exec env FLOCKER="$0" flock -n "$0" "$0" "$@" || :
+
 readonly BACKUP_LOCAL_DIR="/backup"
 readonly BACKUP_DIRS=($BACKUP_LOCAL_DIR /home /root /etc /var/www)
 
@@ -33,15 +36,6 @@ log() {
   # Interactive shell
   if tty -s; then
     echo $MSG
-  fi
-}
-
-check_only_instance() {
-  local self=$(basename $0)
-
-  if pidof -o %PPID -x "$self" >/dev/null; then
-    log "Already running"
-    exit 0
   fi
 }
 


### PR DESCRIPTION
The purpose of the `check_only_instances()` function is to ensure that
only one instance of the script runs at a time, and the purpose of this
change is to increase portability of the 'backup' script.

The `pidof` command on Debian has different options than the BSD variant.
The flock(1) functionality can achieve the same result with increased
portability.

The `flock` call at the top of the script uses the 'backup' script
itself as a file lock, fulfilling the single instance criteria by
disallowing other instances of the script to try and claim that same
lock.

For more information, see the man page for flock(1).