### PR TITLE
Backup biggest period only

### DIFF
--- a/backup
+++ b/backup
@@ -4,7 +4,7 @@
 #               We strongly recommend to put this in /etc/cron.hourly/backup
 # Author:       Roy Arisse <support@perfacilis.com>
 # See:          https://www.perfacilis.com/blog/systeembeheer/linux/rsync-daily-weekly-monthly-incremental-back-ups.html
-# Version:      0.10.2
+# Version:      0.11
 # Usage:        bash /etc/cron.hourly/backup
 
 readonly BACKUP_LOCAL_DIR="/backup"
@@ -107,7 +107,7 @@ get_next_increment() {
   fi
 
   NEXT=$(($LAST+1))
-  if [ "$NEXT" -gt "$LIMIT" ]; then
+  if [ "$NEXT" -ge "$LIMIT" ]; then
     echo 0
     return
   fi
@@ -115,10 +115,11 @@ get_next_increment() {
   echo $NEXT
 }
 
-get_intervals_to_backup() {
+# Return biggest interval to backup
+get_interval_to_backup() {
   local NOW=$(date +%s)
   local LAST PERIOD INCFILE DURATION DIFF
-  local PERIODS=()
+  local TODO=""
 
   for PERIOD in "${!DURATIONS[@]}"; do
     # Skip disabled intervals
@@ -134,12 +135,12 @@ get_intervals_to_backup() {
 
     DURATION=${DURATIONS[$PERIOD]}
     DIFF=$(($NOW - $LAST))
-    if [ $DIFF -gt $DURATION ]; then
-      PERIODS+=("$PERIOD")
+    if [ $DIFF -ge $DURATION ]; then
+      TODO="$PERIOD"
     fi
   done
 
-  echo "${PERIODS[*]}"
+  echo "$TODO"
 }
 
 get_rsync_opts() {
@@ -169,7 +170,7 @@ get_rsync_opts() {
 }
 
 backup_packagelist() {
-  local TODO=$(get_intervals_to_backup)
+  local TODO=$(get_interval_to_backup)
 
   if [ -z "$TODO" ]; then
     return
@@ -180,7 +181,7 @@ backup_packagelist() {
 }
 
 backup_mysql() {
-  local TODO=$(get_intervals_to_backup)
+  local TODO=$(get_interval_to_backup)
   local DB
 
   if [ -z "$TODO" ]; then
@@ -207,47 +208,43 @@ backup_folders() {
   local RSYNC_OPTS=$(get_rsync_opts)
   local DIR TARGET INC INCDIR
   local VANISHED='^(file has vanished: |rsync warning: some files vanished before they could be transferred)'
-  local TODO=$(get_intervals_to_backup)
+  local PERIOD=$(get_interval_to_backup)
 
-  if [ -z "$TODO" ]; then
+  if [ -z "$PERIOD" ]; then
     log "No intervals to back-up yet."
     exit
   fi
 
-  for PERIOD in $TODO; do
-    INC=$(get_next_increment $PERIOD)
-    log "Moving $PERIOD back-up to target: $INC"
+  INC=$(get_next_increment $PERIOD)
+  log "Moving $PERIOD back-up to target: $INC"
 
-    for DIR in ${BACKUP_DIRS[@]}; do
-      TARGET=${DIR/#\//}
-      TARGET=${TARGET//\//_}
+  prepare_remote_dir "current"
 
-      # Make path absolute if target is not remote (not user@host)
-      INCDIR="/$PERIOD/$INC/$TARGET"
-      if echo $RSYNC_TARGET | grep -qv "@"; then
-        INCDIR="$RSYNC_TARGET$INCDIR"
-      fi
+  for DIR in ${BACKUP_DIRS[@]}; do
+    TARGET=${DIR/#\//}
+    TARGET=${TARGET//\//_}
 
-      log "- $DIR"
-      prepare_remote_dir "current"
-      rsync $RSYNC_OPTS --backup --backup-dir=$INCDIR \
-        $DIR/ $RSYNC_TARGET/current/$TARGET 2>&1 | (egrep -v "$VANISHED" || true)
-    done
+    # Make path absolute if target is not remote (not user@host)
+    INCDIR="/$PERIOD/$INC/$TARGET"
+    if echo $RSYNC_TARGET | grep -qv "@"; then
+      INCDIR="$RSYNC_TARGET$INCDIR"
+    fi
 
+    log "- $DIR"
+    rsync $RSYNC_OPTS --backup --backup-dir=$INCDIR \
+      $DIR/ $RSYNC_TARGET/current/$TARGET 2>&1 | (egrep -v "$VANISHED" || true)
   done
 }
 
 signoff_increments() {
   local STARTTIME="$1"
-  local TODO=$(get_intervals_to_backup)
-  local PERIOD INC INCFILE
+  local PERIOD=$(get_interval_to_backup)
+  local INC INCFILE
 
-  for PERIOD in $TODO; do
-    INC=$(get_next_increment $PERIOD)
-    INCFILE=$(get_last_inc_file $PERIOD)
-    echo $INC > "$INCFILE"
-    touch -t "$STARTTIME" "$INCFILE"
-  done
+  INC=$(get_next_increment $PERIOD)
+  INCFILE=$(get_last_inc_file $PERIOD)
+  echo $INC > "$INCFILE"
+  touch -t "$STARTTIME" "$INCFILE"
 }
 
 cleanup() {


### PR DESCRIPTION
Feature: Only return biggest interval, to ensure most important interval is always updated. Old behaviour didn't work, because first run updated `current` directory, therefore 2nd run did nothing.
Fix: Off by one error, resulting in one increment too many per interval.
Fix: Off by one error, resulting in interval taking one second longer than necessary.
Fix: Move `prepare_remote_dir "current"` up so it get's called less.
Bump version to 0.11