### PR TITLE
Backup rsync over ssh

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,42 @@ sudo /etc/cron.hourly/backup
 tail -f /var/log/syslog | grep --color --line-buffered "backup:"
 ```
 
+## Basic usage
+
+### Rsync profile
+
+Default usage, backup to a server with an Rsync profile:
+
+```bash
+readonly RSYNC_TARGET="username@backup.perfacilis.com::profile"
+readonly RSYNC_DEFAULTS="-trlqpz4 --delete --delete-excluded --prune-empty-dirs"
+readonly RSYNC_EXCLUDE=(tmp/ temp/)
+readonly RSYNC_SECRET='RSYNCSECRETHERE'
+```
+
+### Local backup
+
+If you want to backup to a USB disk for example:
+
+```bash
+readonly RSYNC_TARGET="/media/user/backup_drive"
+readonly RSYNC_DEFAULTS="-trlqpz4 --delete --delete-excluded --prune-empty-dirs"
+readonly RSYNC_EXCLUDE=(tmp/ temp/)
+readonly RSYNC_SECRET=''
+```
+
+### Rsync over ssh
+
+Rsync using ssh to communicate instead of rsync profiles.
+You'll have to set up SSH Public Key authentication:
+
+```bash
+readonly RSYNC_TARGET="username@backup.perfacilis.com:/path/on/ssh/server"
+readonly RSYNC_DEFAULTS="-trlqpz4 --delete --delete-excluded --prune-empty-dirs -e 'ssh'"
+readonly RSYNC_EXCLUDE=(tmp/ temp/)
+readonly RSYNC_SECRET=''
+```
+
 ## Contributing
 
 Any bugs or ideas for improvement can be reported using GitHub's Issues thingy.

--- a/backup
+++ b/backup
@@ -4,7 +4,7 @@
 #               We strongly recommend to put this in /etc/cron.hourly/backup
 # Author:       Roy Arisse <support@perfacilis.com>
 # See:          https://www.perfacilis.com/blog/systeembeheer/linux/rsync-daily-weekly-monthly-incremental-back-ups.html
-# Version:      0.11.1
+# Version:      0.12
 # Usage:        bash /etc/cron.hourly/backup
 
 readonly BACKUP_LOCAL_DIR="/backup"
@@ -225,10 +225,11 @@ backup_folders() {
     TARGET=${DIR/#\//}
     TARGET=${TARGET//\//_}
 
-    # Make path absolute if target is not remote (not user@host)
+    # Make path absolute if target is not RSYNC profile
+    # Also remove "user@server:" for SSH setups
     INCDIR="/$PERIOD/$INC/$TARGET"
-    if echo $RSYNC_TARGET | grep -qv "@"; then
-      INCDIR="$RSYNC_TARGET$INCDIR"
+    if [ -z "$RSYNC_SECRET" ]; then
+      INCDIR="${RSYNC_TARGET##*:}$INCDIR"
     fi
 
     log "- $DIR"


### PR DESCRIPTION
Feature: Added support for backing up using rsync over ssh. Also added minimal guidlines for the three backup optins the script supports. Bump version to 0.12