### PR TITLE
Encrypted mysql backups

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,38 @@ readonly RSYNC_EXCLUDE=(tmp/ temp/)
 readonly RSYNC_SECRET=''
 ```
 
+## Mysqldump
+
+When `$MYSQL` and `$MYSQLDUMP` are not empty, the script tries to backup all 
+databases into a GZIP file. Therefore, leave these empty if you don't want to 
+backup mysql.
+
+MySQL credentials can be set trough one of the following methods:
+1. Defaults file: `--defaults-file=/etc/mysql/debian.cnf`
+2. Extra defailts file: `--defaults-extra-file=/root/.mysqldump`
+      ```bash
+      [mysql]
+      user=USERNAME
+      password=PASSWORD
+
+      [mysqldump]
+      user=USERNAME
+      password=PASSWORD
+      ```
+3. Inline (not recommended): `--user=USERNAME --password=PASSWORD`
+
+### Mysqldump encryption
+If you set `$MYSQLDUMP_PUBLIC_KEY`, the GZIP file will be encrypted using that 
+public key. You can generate a public key using:
+    `openssl req -x509 -nodes -newkey rsa:2048 -keyout PRIVATE.key -out PUBLIC.pem`
+
+If your mysql instance has encryption enabled, change `$MYSQLDUMP` accordingly:
+    `mysqldump --defaults-file=/etc/mysql/debian.cnf --ssl-mode=VERIFY_CA --ssl-ca=ca.pem --ssl-cert=client-cert.pem --ssl-key=client-key.pem`
+
+### Mysqldump decryption
+Finally, the encrypted GZIP file can be decrypted using the private key:
+    `openssl smime -decrypt -inform DER -in EXAMPLE.sql.gz.enc -inkey PRIVATE.key > EXAMPLE.sql.gz`
+
 ## Contributing
 
 Any bugs or ideas for improvement can be reported using GitHub's Issues thingy.

--- a/backup
+++ b/backup
@@ -3,8 +3,8 @@
 # Description:  Create back-ups of dirs and dbs by copying them to Perfacilis' back-up servers
 #               We strongly recommend to put this in /etc/cron.hourly/backup
 # Author:       Roy Arisse <support@perfacilis.com>
-# See:          https://www.perfacilis.com/blog/systeembeheer/linux/rsync-daily-weekly-monthly-incremental-back-ups.html
-# Version:      0.12.2
+# See:          https://github.com/perfacilis/backup
+# Version:      0.13
 # Usage:        bash /etc/cron.hourly/backup
 
 readonly BACKUP_LOCAL_DIR="/backup"
@@ -17,6 +17,7 @@ readonly RSYNC_SECRET='RSYNCSECRETHERE'
 
 readonly MYSQL="mysql --defaults-file=/etc/mysql/debian.cnf"
 readonly MYSQLDUMP="mysqldump --defaults-file=/etc/mysql/debian.cnf -E -R --max-allowed-packet=512MB -q --single-transaction -Q --skip-comments"
+readonly MYSQLDUMP_PUBLIC_KEY=""
 
 # Amount of increments per interval and duration per interval resp.
 readonly -A INCREMENTS=([hourly]=24 [daily]=7 [weekly]=4 [monthly]=12 [yearly]=5)
@@ -201,7 +202,11 @@ backup_mysql() {
     fi
 
     log "- $DB"
-    $MYSQLDUMP $DB | gzip --rsyncable > $BACKUP_LOCAL_DIR/$DB.sql.gz
+    if [ -z "$MYSQLDUMP_PUBLIC_KEY" ]; then
+      $MYSQLDUMP $DB | gzip --rsyncable > $BACKUP_LOCAL_DIR/$DB.sql.gz
+    else
+      $MYSQLDUMP $DB | gzip -c | openssl smime -encrypt -binary -text -aes256 -out $BACKUP_LOCAL_DIR/$DB.sql.gz.enc -outform DER $MYSQLDUMP_PUBLIC_KEY
+    fi
   done
 }
 


### PR DESCRIPTION
Feature: If `$MYSQLDUMP_PUBLIC_KEY` is set, use that as public key file to encrypt dumped GZIPs.
Feature: Added explanation in README.md how encryption / decryption works