### PR TITLE
Remove flock, use simple file instead

### DIFF
--- a/backup
+++ b/backup
@@ -39,14 +39,15 @@ log() {
 }
 
 check_only_instance() {
-  # Assign file handle Bob to this script, because we can
-  exec 808<$0
-  flock -n 808
+  local lockfile="$BACKUP_LOCAL_DIR/lock"
 
-  if [ $? -gt 0 ]; then
+  if [ -f $lockfile ]; then
     log "Already running"
     exit 0
   fi
+
+  date > $lockfile
+  trap "rm -f $lockfile" EXIT
 }
 
 prepare_local_dir() {
@@ -266,8 +267,8 @@ main() {
 
   trap "cleanup" EXIT
 
-  check_only_instance
   prepare_local_dir
+  check_only_instance
 
   backup_packagelist
   backup_mysql


### PR DESCRIPTION
Fix: Makes only instance check easier to understand and works just as good. Also logs "Already running" properly now.