### PR TITLE
PostgreSQL backup

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ whatsoever.
 
 **Please check the integrity of your back-ups periodically!**
 
+
 ## We're hoping for your feedback...
 
 ![GIF I like it a lot](https://i.imgflip.com/lo6p.gif)
@@ -21,6 +22,7 @@ Tried this script for a bit? Like it? Or hate it?
 It would help my business like a lot if you would take just 60 seconds out of 
 your time and tell us what you think:
 http://g.page/perfacilis/review
+
 
 ## Installation
 
@@ -32,7 +34,7 @@ few lines of the script and install it as an (hourly) cronjob. For example:
 ```bash
 # Never copy-pasta stuff from the webz into your terminal, always check first!
 wget -qO- https://raw.githubusercontent.com/perfacilis/backup/master/backup | sudo tee /etc/cron.hourly/backup
-sudo chmod +x /etc/cron.hourly/backup
+sudo chmod 700 /etc/cron.hourly/backup
 
 # Change BACKUP_LOCAL_DIR, BACKUP_DIRS, etc
 nano /etc/cron.hourly/backup
@@ -48,7 +50,7 @@ tail -f /var/log/syslog | grep --color --line-buffered "backup:"
 
 First, you'll need a Windows implementation of Rsync, for example:
     https://itefix.net/cwrsync-client
-Download the zip and extract so you get "C:\backup\rsync\bin\rsync.exe"
+Download the zip and extract so you get `C:\backup\rsync\bin\rsync.exe`
 
 Then, like the Linux installation, download the latest version, change the 
 variables in the first few lines and install a Scheduled Task. For example:
@@ -110,37 +112,71 @@ readonly RSYNC_EXCLUDE=(tmp/ temp/)
 readonly RSYNC_SECRET=''
 ```
 
-## Mysqldump
 
-When `$MYSQL` and `$MYSQLDUMP` are not empty, the script tries to backup all 
-databases into a GZIP file. Therefore, leave these empty if you don't want to 
-backup mysql.
+## Databases
 
-MySQL credentials can be set trough one of the following methods:
-1. Defaults file: `--defaults-file=/etc/mysql/debian.cnf`
-2. Extra defailts file: `--defaults-extra-file=/root/.mysqldump`
-      ```bash
-      [mysql]
-      user=USERNAME
-      password=PASSWORD
+When `$DB_LIST` is not empty, the script tries to backup all listed names into 
+a GZIP file. Therefore, leave empty if you don't want to backup databases. For
+every database, `$DB_DUMP` is run, so change this according to your database 
+system.
 
-      [mysqldump]
-      user=USERNAME
-      password=PASSWORD
-      ```
-3. Inline (not recommended): `--user=USERNAME --password=PASSWORD`
+See some examples below.
 
-### Mysqldump encryption
-If you set `$MYSQLDUMP_PUBLIC_KEY`, the GZIP file will be encrypted using that 
+### MySQL examples
+For **MariaDB** use `mariadb` instead of `mysql` and `mariadb-dump` instead of
+`mysqldump`.
+
+```bash
+readonly DB_LIST="database1 database2"
+readonly DB_LIST="$(mysql --defaults-file=/etc/mysql/debian.cnf -e "SHOW DATABASES;" -B -N | grep -v 'Database')"
+
+readonly DB_DUMP="mysqldump --defaults-file=/etc/mysql/debian.cnf -E -R --max-allowed-packet=512MB -q --single-transaction -Q --skip-comments"
+readonly DB_NAME="mysqldump --defaults-file=/etc/mysql/debian.cnf --ssl-mode=VERIFY_CA --ssl-ca=ca.pem --ssl-cert=client-cert.pem --ssl-key=client-key.pem -E -R --max-allowed-packet=512MB -q --single-transaction -Q --skip-comments"
+readonly DB_DUMP="mysqldump --defaults-extra-file=/root/.mysqldump -E -R --max-allowed-packet=512MB -q --single-transaction -Q --skip-comments"
+readonly DB_DUMP="mysqldump --username=PLSDONT --password=PLSDONT -E -R --max-allowed-packet=512MB -q --single-transaction -Q --skip-comments"
+```
+
+Example of `/root/.mysqldump` file:
+```bash
+[mysql]
+user=USERNAME
+password=PASSWORD
+
+[mysqldump]
+user=USERNAME
+password=PASSWORD
+```
+
+### PostgreSQL examples
+
+```bash
+readonly DB_LIST="$(psql -h 127.0.0.1 -U restore --no-password -l -t | grep '^ \w' | grep -v 'template' | awk '{print $1}')"
+readonly DB_DUMP="pg_dump -h 127.0.0.1 -U restore --no-password -d"
+```
+
+It's recommended to create a user to allow databases to be dumped without user
+interaction:
+```bash
+sudo -u postgres psql -c "CREATE USER restore SUPERUSER PASSWORD 'secret';"
+sudo -u postgres psql -c "GRANT pg_read_all_data TO restore;
+echo '*:*:*:restore:SECRETPASSWORD' | sudo tee /root/.pgpass
+sudo chmod 600 /root/.pgpass
+```
+
+### Database encryption
+If you set `$DB_ENCRYPTION_KEY`, the GZIP file will be encrypted using that 
 public key. You can generate a public key using:
-    `openssl req -x509 -nodes -newkey rsa:2048 -keyout PRIVATE.key -out PUBLIC.pem`
 
-If your mysql instance has encryption enabled, change `$MYSQLDUMP` accordingly:
-    `mysqldump --defaults-file=/etc/mysql/debian.cnf --ssl-mode=VERIFY_CA --ssl-ca=ca.pem --ssl-cert=client-cert.pem --ssl-key=client-key.pem`
+```bash
+openssl req -x509 -nodes -newkey rsa:2048 -keyout PRIVATE.key -out PUBLIC.pem
+```
 
-### Mysqldump decryption
-Finally, the encrypted GZIP file can be decrypted using the private key:
-    `openssl smime -decrypt -inform DER -in EXAMPLE.sql.gz.enc -inkey PRIVATE.key > EXAMPLE.sql.gz`
+The encrypted GZIP file can be decrypted using the private key:
+
+```bash
+openssl smime -decrypt -inform DER -in EXAMPLE.sql.gz.enc -inkey PRIVATE.key > EXAMPLE.sql.gz
+```
+
 
 ## Contributing
 

--- a/backup
+++ b/backup
@@ -4,7 +4,7 @@
 #               We strongly recommend to put this in /etc/cron.hourly/backup
 # Author:       Roy Arisse <support@perfacilis.com>
 # See:          https://github.com/perfacilis/backup
-# Version:      0.13.1
+# Version:      0.14
 # Usage:        bash /etc/cron.hourly/backup
 
 readonly BACKUP_LOCAL_DIR="/backup"
@@ -15,9 +15,9 @@ readonly RSYNC_DEFAULTS="-trlqpz4 --delete --delete-excluded --prune-empty-dirs"
 readonly RSYNC_EXCLUDE=(tmp/ temp/)
 readonly RSYNC_SECRET='RSYNCSECRETHERE'
 
-readonly MYSQL="mysql --defaults-file=/etc/mysql/debian.cnf"
-readonly MYSQLDUMP="mysqldump --defaults-file=/etc/mysql/debian.cnf -E -R --max-allowed-packet=512MB -q --single-transaction -Q --skip-comments"
-readonly MYSQLDUMP_PUBLIC_KEY=""
+readonly DB_LIST="$(mysql --defaults-file=/etc/mysql/debian.cnf -e 'show databases' | grep -v 'Database')"
+readonly DB_DUMP="mysqldump --defaults-file=/etc/mysql/debian.cnf -E -R --max-allowed-packet=512MB -q --single-transaction -Q --skip-comments"
+readonly DB_ENCRYPTION_KEY=""
 
 # Amount of increments per interval and duration per interval resp.
 readonly -A INCREMENTS=([hourly]=24 [daily]=7 [weekly]=4 [monthly]=12 [yearly]=5)
@@ -183,30 +183,26 @@ backup_packagelist() {
   dpkg --get-selections > $BACKUP_LOCAL_DIR/packagelist.txt
 }
 
-backup_mysql() {
-  local TODO=$(get_interval_to_backup)
-  local DB
+backup_databases() {
+  local TODO DB
+  TODO=$(get_interval_to_backup)
 
   if [ -z "$TODO" ]; then
     return
   fi
 
-  if [ -z "$MYSQL" -o -z "$MYSQLDUMP" ]; then
-    log "MySQL not set up, skipping database backup."
+  if [ -z "$DB_LIST" ] || [ -z "$DB_DUMP" ]; then
+    log "Skipping database backup!"
     return
   fi
 
-  log "Back-up mysql databases:"
-  for DB in `$MYSQL -e 'show databases' | grep -v 'Database'`; do
-    if [ $DB = 'information_schema' -o $DB = 'performance_schema' ]; then
-      continue
-    fi
-
+  log "Back-up databases:"
+  for DB in $DB_LIST; do
     log "- $DB"
-    if [ -z "$MYSQLDUMP_PUBLIC_KEY" ]; then
-      $MYSQLDUMP $DB | gzip --rsyncable > $BACKUP_LOCAL_DIR/$DB.sql.gz
+    if [ -z "$DB_ENCRYPTION_KEY" ]; then
+      $DB_DUMP "$DB" | gzip --rsyncable > "$BACKUP_LOCAL_DIR/$DB.sql.gz"
     else
-      $MYSQLDUMP $DB | gzip -c | openssl smime -encrypt -binary -text -aes256 -out $BACKUP_LOCAL_DIR/$DB.sql.gz.enc -outform DER $MYSQLDUMP_PUBLIC_KEY
+      $DB_DUMP "$DB" | gzip -c | openssl smime -encrypt -binary -text -aes256 -out "$BACKUP_LOCAL_DIR/$DB.sql.gz.enc" -outform DER "$DB_ENCRYPTION_KEY"
     fi
   done
 }
@@ -271,7 +267,7 @@ main() {
   check_only_instance
 
   backup_packagelist
-  backup_mysql
+  backup_databases
   backup_folders
 
   signoff_increments $starttime


### PR DESCRIPTION
Fix: Change `chmod +x` to `chmod 700` to make backup executable by root only.
Feature: Readme shows examples how to backup MySQL / MariaDB and PostgreSQL.
Feature: Backup of databases more generic to allow any back-end, or at least more than only MySQL.
Bump version to 0.14