### PR TITLE
Rsync not working due to mangled options

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ You'll have to set up SSH Public Key authentication:
 
 ```bash
 readonly RSYNC_TARGET="username@backup.perfacilis.com:/path/on/ssh/server"
-readonly RSYNC_DEFAULTS="-trlqpz4 --delete --delete-excluded --prune-empty-dirs -e 'ssh'"
+readonly RSYNC_DEFAULTS="-trlqpz4 --delete --delete-excluded --prune-empty-dirs -e "'"ssh -p 2222"'""
 readonly RSYNC_EXCLUDE=(tmp/ temp/)
 readonly RSYNC_SECRET=''
 ```

--- a/backup
+++ b/backup
@@ -8,7 +8,7 @@
 # Usage:        bash /etc/cron.hourly/backup
 
 readonly BACKUP_LOCAL_DIR="/backup"
-readonly BACKUP_DIRS=($BACKUP_LOCAL_DIR /home /root /etc /var/www)
+readonly BACKUP_DIRS=("$BACKUP_LOCAL_DIR" /home /root /etc /var/www)
 
 readonly RSYNC_TARGET="username@backup.perfacilis.com::profile"
 readonly RSYNC_DEFAULTS="-trlqpz4 --delete --delete-excluded --prune-empty-dirs"
@@ -147,10 +147,10 @@ get_interval_to_backup() {
 }
 
 get_rsync_opts() {
+  local EXCLUDE SECRET OPTS
   EXCLUDE=$(dirname $0)/rsync.exclude
   SECRET=$(dirname $0)/rsync.secret
   OPTS=$RSYNC_DEFAULTS
-  local EXCLUDE SECRET OPTS
 
   if [ -n "$RSYNC_EXCLUDE" ]; then
     if [ ! -f $EXCLUDE ]; then


### PR DESCRIPTION
Fix: Define variables before setting them, keeping Shellcheck working
Fix: Working example of how to escape `-e 'ssh -p 2222'` argument to rsync options.