### PR TITLE
Fix quoting to allow backup of directories with spaces

### DIFF
--- a/backup.ps1
+++ b/backup.ps1
@@ -216,7 +216,7 @@ function backup_folders() {
         $DIR_CYG=$(prefix_cygdrive $DIR)
 
         log "- $DIR"
-        $ARGS="$RSYNC_OPTS --backup --backup-dir=$INCDIR $DIR_CYG/ $RSYNC_TARGET_CYG/current/$TARGET"
+        $ARGS="$RSYNC_OPTS --backup --backup-dir=`"$INCDIR`" `"$DIR_CYG/`" `"$RSYNC_TARGET_CYG/current/$TARGET`""
         Start-Process -FilePath "$RSYNC" -ArgumentList "$ARGS" -Wait -NoNewWindow
     }
 }


### PR DESCRIPTION
Root directories with a space in their name failed to backup; this patch fixes that behaviour.