### PR TITLE
Experimental: Cleanup rsync secret and log file

### DIFF
--- a/backup
+++ b/backup
@@ -47,7 +47,7 @@ check_only_instance() {
   fi
 
   date > $lockfile
-  trap "rm -f $lockfile" EXIT
+  trap "rm -f $lockfile" EXIT SIGINT SIGTERM ERR
 }
 
 prepare_local_dir() {
@@ -253,8 +253,10 @@ signoff_increments() {
 }
 
 cleanup() {
-  rm -f `dirname $0`/rsync.exclude
-  rm -f `dirname $0`/rsync.secret
+  log "Cleanup"
+  rm -f "$(dirname $0)/rsync.exclude"
+  rm -f "$(dirname $0)/rsync.secret"
+  exit
 }
 
 main() {
@@ -262,7 +264,7 @@ main() {
 
   log "Back-up initiated at `date`"
 
-  trap "cleanup" EXIT
+  trap "cleanup" EXIT SIGINT SIGTERM ERR
 
   prepare_local_dir
   check_only_instance


### PR DESCRIPTION
Fix: Call `trap` on normal EXIT, CTRL+C (SIGINT), Kill (SIGTERM) or Error (ERR).
Fix: Apply signals to ensure `rsync.secret` and `rsync.exclude` are deleted to avoid leaving credentials.
Fix: Apply signals to ensrue `lock` is deleted, to avoid cron nog ever running after CTRL+C.