### PR TITLE
Remove lock file atfer 1 day

### DIFF
--- a/backup
+++ b/backup
@@ -4,7 +4,7 @@
 #               We strongly recommend to put this in /etc/cron.hourly/backup
 # Author:       Roy Arisse <support@perfacilis.com>
 # See:          https://github.com/perfacilis/backup
-# Version:      0.15
+# Version:      0.15.1
 # Usage:        bash /etc/cron.hourly/backup
 
 readonly BACKUP_LOCAL_DIR="/backup"
@@ -41,15 +41,24 @@ log() {
 }
 
 check_only_instance() {
-  local lockfile="$BACKUP_LOCAL_DIR/lock"
+  local LOCKFILE="$BACKUP_LOCAL_DIR/lock"
+  local NOW LAST=0 DIFF
 
-  if [ -f $lockfile ]; then
-    log "Already running"
-    exit 0
+  if [ -f "$LOCKFILE" ]; then
+    NOW=$(date +%s)
+    LAST=$(date -r "$LOCKFILE" +%s)
+    DIFF=$((NOW - LAST))
+    if [ $DIFF -ge 86400 ]; then
+      log "Remove lockfile after one day"
+      rm "$LOCKFILE"
+    else
+      log "Already running"
+      exit 0
+    fi
   fi
 
-  date > $lockfile
-  trap "rm -f $lockfile" EXIT SIGINT SIGTERM ERR
+  date > $LOCKFILE
+  trap "rm -f $LOCKFILE" EXIT SIGINT SIGTERM ERR
 }
 
 prepare_local_dir() {
@@ -140,7 +149,7 @@ get_interval_to_backup() {
       LAST=$(date -r "$INCFILE" +%s)
     fi
 
-    DIFF=$(($NOW - $LAST))
+    DIFF=$((NOW - LAST))
     if [ $DIFF -ge $DURATION ]; then
       echo "$PERIOD"
       break


### PR DESCRIPTION
Fix: When lock file isn't removed (after error) backup doesn't run anymore. Therfore, we delete lock file after 1 day forcefully.